### PR TITLE
Provide a place to add custom ROS code for scuttle components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,206 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(scuttle_model)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+# add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  rospy
+  roscpp
+  scuttle_description
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a exec_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs  # Or other packages containing msgs
+# )
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES scuttle_model
+#  CATKIN_DEPENDS rospy scuttle_description
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+# include
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a C++ library
+# add_library(${PROJECT_NAME}
+#   src/${PROJECT_NAME}/scuttle_model.cpp
+# )
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
+## With catkin_make all packages are built within a single CMake context
+## The recommended prefix ensures that target names across packages don't collide
+# add_executable(${PROJECT_NAME}_node src/scuttle_model_node.cpp)
+
+## Rename C++ executable without prefix
+## The above recommended prefix causes long target names, the following renames the
+## target back to the shorter version for ease of user use
+## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
+# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+# target_link_libraries(${PROJECT_NAME}_node
+#   ${catkin_LIBRARIES}
+# )
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# catkin_install_python(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables for installation
+## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_executables.html
+# install(TARGETS ${PROJECT_NAME}_node
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark libraries for installation
+## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_libraries.html
+# install(TARGETS ${PROJECT_NAME}
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_scuttle_model.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # scuttle_model
-Provides the description of the SCUTTLE robot for ROS and Gazebo
+
+Provides a user customizable wrapper for `scuttle_desciption`.
+
+## Dependencies
+
+The configurations in this repository assume you have the following prerequisites installed on the
+device on which you want to run this code. That device might be an Ubuntu machine or a physical
+SCUTTLE using Raspberry Pi OS.
+
+1. [ROS Noetic](http://wiki.ros.org/noetic) with the `ros-noetic-navigation`, `ros-noetic-robot` and
+   `ros-noetic-tf2` packages.
+1. A working [ROS workspace](http://wiki.ros.org/catkin/Tutorials/create_a_workspace).
+1. The [scuttle_description](https://github.com/scuttlerobot/scuttle_description) package installed
+   in your workspace.
+
+
+## Usage
+
+- Clone this repo and add your own components to the URDF file
+- There shouldn't be many changes to this repository so you won't have to worry about merge conflicts
+
+## Configurations

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # scuttle_model
 
-Provides a user customizable wrapper for `scuttle_desciption`.
+Provides a user customizable wrapper for `scuttle_desciption` that allows you to add your own
+components to SCUTTLE.
 
 ## Dependencies
 
@@ -14,10 +15,14 @@ SCUTTLE using Raspberry Pi OS.
 1. The [scuttle_description](https://github.com/scuttlerobot/scuttle_description) package installed
    in your workspace.
 
-
 ## Usage
 
-- Clone this repo and add your own components to the URDF file
-- There shouldn't be many changes to this repository so you won't have to worry about merge conflicts
+To use the `scuttle_model` package you need to take the following steps
 
-## Configurations
+1. Clone this repo into the `src` directory of your ROS workspace
+1. Create a new URDF file in the `urdf` directory. Add your own components to this new URDF file.
+1. Add a link to your URDF file in the `urdf/scuttle.xacro` file.
+1. Build your workspace using `catkin_make`
+
+Once you have taken these steps you can run your model in Gazebo, for instance using one of the
+worlds defined in the [scuttle_gazebo](https://github.com/scuttlerobot/scuttle_gazebo) repository.

--- a/config/twist_mux_locks.yaml
+++ b/config/twist_mux_locks.yaml
@@ -1,0 +1,33 @@
+# Locks to stop the twist inputs.
+# For each lock:
+# - topic   : input topic that provides the lock; it must be of type std_msgs::Bool?!!!
+# - timeout : == 0.0 -> not used
+#              > 0.0 -> the lock is supposed to published at a certain frequency in order
+#                       to detect that the publisher is alive; the timeout in seconds allows
+#                       to detect that, and if the publisher dies we will enable the lock
+# - priority: priority in the range [0, 255], so all the topics with priority lower than it
+#             will be stopped/disabled
+
+locks:
+-
+  name    : pause
+  topic   : pause_navigation
+  timeout : 0.0
+  # Same priority as joystick control, so it'll not block it.
+  priority: 100
+-
+  name    : loop_closure
+  topic   : stop_closing_loop
+  timeout : 0.0
+  priority: 200
+-
+  name    : e-stop
+  topic   : e_stop
+  timeout : 0.0
+  priority: 255
+-
+  name    : joystick
+  topic   : joy_priority
+  timeout : 0.0
+  priority: 100
+

--- a/config/twist_mux_topics.yaml
+++ b/config/twist_mux_topics.yaml
@@ -1,0 +1,33 @@
+# Input topics handled/muxed.
+# For each topic:
+# - name    : name identifier to select the topic
+# - topic   : input topic of geometry_msgs::Twist type
+# - timeout : timeout in seconds to start discarding old messages, and use 0.0 speed instead
+# - priority: priority in the range [0, 255]; the higher the more priority over other topics
+
+topics:
+-
+  name    : navigation
+  topic   : nav_vel
+  timeout : 0.5
+  priority: 10
+-
+  name    : bumper response
+  topic   : bumper_vel
+  timeout : 0.5
+  priority: 75
+-
+  name    : joystick
+  topic   : joy_vel
+  timeout : 0.5
+  priority: 100
+-
+  name    : keyboard
+  topic   : key_vel
+  timeout : 0.5
+  priority: 50
+-
+  name    : tablet
+  topic   : tab_vel
+  timeout : 0.5
+  priority: 100

--- a/launch/scuttle_model.launch
+++ b/launch/scuttle_model.launch
@@ -13,5 +13,7 @@
     <arg name="is_physical" default="true"/>
 
 
-
+    <!--
+        Start your own ROS nodes here
+    -->
 </launch>

--- a/launch/scuttle_model.launch
+++ b/launch/scuttle_model.launch
@@ -1,0 +1,17 @@
+<launch>
+    <!--
+        Use this launch file to launch all the nodes you need for your additional SCUTTLE parts to
+        function.
+
+        A number of parameters are available that help you figure out what the environment looks like.
+    -->
+
+    <!--
+        Indicates if ROS is running on a physical SCUTTLE (value = true) or a virtual one
+        (value = false), e.g. when running in Gazebo.
+    -->
+    <arg name="is_physical" default="true"/>
+
+
+
+</launch>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>scuttle_model</name>
+  <version>0.0.0</version>
+  <description>The scuttle_model package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="petrik@todo.todo">Petrik van der Velde</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>ApacheV2</license>
+
+
+  <!-- Url tags are optional, but multiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/scuttle_model</url> -->
+
+
+  <!-- Author tags are optional, multiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintainers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
+  <!--   <depend>roscpp</depend> -->
+  <!--   Note that this is equivalent to the following: -->
+  <!--   <build_depend>roscpp</build_depend> -->
+  <!--   <exec_depend>roscpp</exec_depend> -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use build_export_depend for packages you need in order to build against this package: -->
+  <!--   <build_export_depend>message_generation</build_export_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use exec_depend for packages you need at runtime: -->
+  <!--   <exec_depend>message_runtime</exec_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <!-- Use doc_depend for packages you need only for building documentation: -->
+  <!--   <doc_depend>doxygen</doc_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>scuttle_description</build_depend>
+  <build_export_depend>rospy</build_export_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>scuttle_description</build_export_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>scuttle_description</exec_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/urdf/scuttle.xacro
+++ b/urdf/scuttle.xacro
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+    <robot name="scuttle" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+    <xacro:include filename="$(find scuttle_description)/urdf/scuttle.xacro" />
+</robot>


### PR DESCRIPTION
The goal for `scuttle_model` is to provide a location where people can link their scuttle parts and the associated ROS components in a single location without having to change `scuttle_description`.

The link order of the packages is:

scuttle_gazebo -> scuttle_bringup -> joint_state_publisher
                                                        -> robot_state_publisher
                                                        -> scuttle_model (scuttle.xacro)
                                                        -> scuttle_driver
                                                        -> scuttle_navigation
                                                        -> twist_mux (http://wiki.ros.org/twist_mux)
                                                        -> scuttle_model                                   -> scuttle_description


The twist_mux package was added so that you can have multiple sources for Twist messages (e.g. navigation, keyboard, joystick, bumper) with a priority order for these sources (e.g. from lowest to highest priority: navigation, keyboard, joystick, bumper).